### PR TITLE
Fix left argument for constraint 2 in r1cs.py

### DIFF
--- a/r1cs.py
+++ b/r1cs.py
@@ -13,7 +13,7 @@ OUT = [
 # A gives us the left argument (right side of equality) of each constraint
 A = [
     [0, 1, 0, 0, 0, 0], # LHARG of 1) x
-    [0, 0, 1, 0, 0, 0], # LHARG of 2) x^2
+    [0, 1, 0, 0, 0, 0], # LHARG of 2) x^2
     [0, -1, 0, 0, 0, 0] # LHARG of 3) -x
 ]
 


### PR DESCRIPTION
in the matrix for A(the left arguments) in the second equation we will retrieve x and not x squared as x is the left side variable